### PR TITLE
Update dapp.js

### DIFF
--- a/lib/transactions/dapp.js
+++ b/lib/transactions/dapp.js
@@ -22,8 +22,8 @@ function createDApp(options, secret, secondSecret) {
 				type: options.type,
 				link: options.link,
 				icon: options.icon,
-				delegates: options.delegates,
-				unlockDelegates: options.unlockDelegates
+				delegates: options.delegates || [],
+				unlockDelegates: options.unlockDelegates || 0
 			}
 		}
 	};


### PR DESCRIPTION
这个两个改动是因为asch-js\lib\transactions\crypto.js 69、70行的 参数, 在使用asch-cli创建dapp时dapp.delegates、dapp.unlockDelegates可能是undefined,所以做个判断给个默认值，否则会报错