### PR TITLE
Update package.json because of release versions of uglify-js only support ECMAScript 5 (ES5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "browserify": "^13.1.0",
     "mocha": "^3.4.2",
     "should": "^9.0.2",
-    "uglify-js": "^2.7.3"
+    "uglify-es": "github:mishoo/UglifyJS2#harmony"
   }
 }


### PR DESCRIPTION
release versions of uglify-js only support ECMAScript 5 (ES5). If you wish to minify ES2015+ (ES6+) code then please use the harmony development branch, see also https://www.npmjs.com/package/uglify-js-es6#harmony