### PR TITLE
asch.crypto update for ASCH 1.4.2

### DIFF
--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -143,8 +143,8 @@ function getBytes(trs, skipSignature, skipSecondSignature) {
 		}
 	}
 
-	if (!skipSecondSignature && trs.signSignature) {
-		var signSignatureBuffer = new Buffer(trs.signSignature, 'hex');
+	if (!skipSecondSignature && trs.secondSignature) {
+		var signSignatureBuffer = new Buffer(trs.secondSignature, 'hex');
 		for (var i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
@@ -203,7 +203,7 @@ function signBytes(bytes, keys) {
 function verify(transaction) {
 	var remove = 64;
 
-	if (transaction.signSignature) {
+	if (transaction.secondSignature) {
 		remove = 128;
 	}
 
@@ -216,7 +216,7 @@ function verify(transaction) {
 
 	var hash = sha256Bytes(data2)
 
-	var signatureBuffer = new Buffer(transaction.signature, "hex");
+	var signatureBuffer = new Buffer(transaction.signatures[0], "hex");
 	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
 	var res = nacl.sign.detached.verify(hash, signatureBuffer, senderPublicKeyBuffer);
 
@@ -224,8 +224,8 @@ function verify(transaction) {
 }
 
 function verifySecondSignature(transaction, publicKey) {
-	var bytes = getBytes(transaction);
-	var data2 = new Buffer(bytes.length - 64);
+	var bytes = getBytes(transaction, true, true);
+	var data2 = new Buffer(bytes.length);
 
 	for (var i = 0; i < data2.length; i++) {
 		data2[i] = bytes[i];
@@ -233,7 +233,7 @@ function verifySecondSignature(transaction, publicKey) {
 
 	var hash = sha256Bytes(data2)
 
-	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
+	var signSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
 	var publicKeyBuffer = new Buffer(publicKey, "hex");
 	var res = nacl.sign.detached.verify(hash, signSignatureBuffer, publicKeyBuffer);
 


### PR DESCRIPTION
Dear @sqfasd , dear @liangpeili 

this pull request updates the `asch.crypto` to work with ASCH 1.4.2. 

In the current `asch-js` version (develop and master branch) are references to `transaction.signSignature` (deprecated, correct is `secondSignature`) and `transaction.signature` (deprecated, correct is `transaction.signatures[0]`).

-------

Also the function `verifySecondSignature` is not up-to-date with the corresponding code in [asch-core/src/base/transaction.js](https://github.com/AschPlatform/asch-core/blob/2a7c8ac33f648ae56b057fa673df1261555874da/src/base/transaction.js#L143-L154)

Current, wrong `verifySecondSignature` function (`asch-js`):  
```js
function verifySecondSignature(transaction, publicKey) {
	var bytes = getBytes(transaction);
	var data2 = new Buffer(bytes.length - 64);

	for (var i = 0; i < data2.length; i++) {
		data2[i] = bytes[i];
	}

	var hash = sha256Bytes(data2)

	var signSignatureBuffer = new Buffer(transaction.signSignature, "hex");
	var publicKeyBuffer = new Buffer(publicKey, "hex");
	var res = nacl.sign.detached.verify(hash, signSignatureBuffer, publicKeyBuffer);

	return res;
}
```

Correct `verifySecondSignature` function (`asch-js`):
```js
function verifySecondSignature(transaction, publicKey) {
	var bytes = getBytes(transaction, true, true);
	var data2 = new Buffer(bytes.length);

	for (var i = 0; i < data2.length; i++) {
		data2[i] = bytes[i];
	}

	var hash = sha256Bytes(data2)

	var signSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
	var publicKeyBuffer = new Buffer(publicKey, "hex");
	var res = nacl.sign.detached.verify(hash, signSignatureBuffer, publicKeyBuffer);

	return res;
}
```

Asch-core skips the signature and  secondSignature by calling `const bytes = self.getBytes(trs, true, true)`. This does `asch-js` not. I fixed this for `asch-js`.

Thank you!
All the best
a1300