### PR TITLE
chore(licence): Add MIT LICENCE file

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Asch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "library"
   ],
   "author": "sqf1225@foxmail.com",
-  "license": "ISC",
+  "license": "MIT",
   "types": "./types/index.d.ts",
   "dependencies": {
     "@types/node": "^10.9.4",


### PR DESCRIPTION
Dear @sqfasd , dear @liangpeili 

I added a MIT LICENCE file. The project was licenced under `ISC` ([wikipedia](https://en.wikipedia.org/wiki/ISC_license)) which is the default licence for __npm__ packages. According to Wikipedia is the `MIT` licence equivalent to `ISC`.

Is this change ok?

Thanks
All the best!
a1300