### PR TITLE
fix(buffer): remove deprecated new Buffer call, closes #22

### DIFF
--- a/lib/transactions/crypto.js
+++ b/lib/transactions/crypto.js
@@ -13,7 +13,7 @@ var fixedPoint = Math.pow(10, 8);
 
 function getSignatureBytes(signature) {
 	var bb = new ByteBuffer(32, true);
-	var publicKeyBuffer = new Buffer(signature.publicKey, "hex");
+	var publicKeyBuffer = Buffer.from(signature.publicKey, "hex");
 
 	for (var i = 0; i < publicKeyBuffer.length; i++) {
 		bb.writeByte(publicKeyBuffer[i]);
@@ -41,26 +41,26 @@ function sha256Hex(data) {
 
 function getDAppBytes(dapp) {
 	try {
-		var buf = new Buffer([]);
-		var nameBuf = new Buffer(dapp.name, "utf8");
+		var buf = Buffer.from([]);
+		var nameBuf = Buffer.from(dapp.name, "utf8");
 		buf = Buffer.concat([buf, nameBuf]);
 
 		if (dapp.description) {
-			var descriptionBuf = new Buffer(dapp.description, "utf8");
+			var descriptionBuf = Buffer.from(dapp.description, "utf8");
 			buf = Buffer.concat([buf, descriptionBuf]);
 		}
 
 		if (dapp.tags) {
-			var tagsBuf = new Buffer(dapp.tags, "utf8");
+			var tagsBuf = Buffer.from(dapp.tags, "utf8");
 			buf = Buffer.concat([buf, tagsBuf]);
 		}
 
 		if (dapp.link) {
-			buf = Buffer.concat([buf, new Buffer(dapp.link, "utf8")]);
+			buf = Buffer.concat([buf, Buffer.from(dapp.link, "utf8")]);
 		}
 
 		if (dapp.icon) {
-			buf = Buffer.concat([buf, new Buffer(dapp.icon, "utf8")]);
+			buf = Buffer.concat([buf, Buffer.from(dapp.icon, "utf8")]);
 		}
 
 		var bb = new ByteBuffer(1, true);
@@ -80,12 +80,12 @@ function getDAppBytes(dapp) {
 
 function getInTransferBytes(inTransfer) {
 	try {
-		var buf = new Buffer([]);
-		var dappId = new Buffer(inTransfer.dappId, "utf8");
-		var currency = new Buffer(inTransfer.currency, "utf8")
+		var buf = Buffer.from([]);
+		var dappId = Buffer.from(inTransfer.dappId, "utf8");
+		var currency = Buffer.from(inTransfer.currency, "utf8")
 		buf = Buffer.concat([buf, dappId, currency]);
 		if (inTransfer.currency !== 'XAS') {
-			var amount = new Buffer(inTransfer.amount, "utf8")
+			var amount = Buffer.from(inTransfer.amount, "utf8")
 			buf = Buffer.concat([buf, amount])
 		}
 	} catch (e) {
@@ -97,11 +97,11 @@ function getInTransferBytes(inTransfer) {
 
 function getOutTransferBytes(outTransfer) {
 	try {
-		var buf = new Buffer([]);
-		var dappIdBuf = new Buffer(outTransfer.dappId, 'utf8');
-		var transactionIdBuff = new Buffer(outTransfer.transactionId, 'utf8');
-		var currencyBuff = new Buffer(outTransfer.currency, 'utf8')
-		var amountBuff = new Buffer(outTransfer.amount, 'utf8')
+		var buf = Buffer.from([]);
+		var dappIdBuf = Buffer.from(outTransfer.dappId, 'utf8');
+		var transactionIdBuff = Buffer.from(outTransfer.transactionId, 'utf8');
+		var currencyBuff = Buffer.from(outTransfer.currency, 'utf8')
+		var amountBuff = Buffer.from(outTransfer.amount, 'utf8')
 		buf = Buffer.concat([buf, dappIdBuf, transactionIdBuff, currencyBuff, amountBuff]);
 	} catch (e) {
 		throw Error(e.toString());
@@ -136,7 +136,7 @@ function getBytes(trs, skipSignature, skipSecondSignature) {
 
 	if (!skipSignature && trs.signatures) {
 		for (let signature of trs.signatures) {
-		  var signatureBuffer = new Buffer(signature, 'hex');
+		  var signatureBuffer = Buffer.from(signature, 'hex');
 		  for (var i = 0; i < signatureBuffer.length; i++) {
 		  	bb.writeByte(signatureBuffer[i]);
 		  }
@@ -144,7 +144,7 @@ function getBytes(trs, skipSignature, skipSecondSignature) {
 	}
 
 	if (!skipSecondSignature && trs.secondSignature) {
-		var signSignatureBuffer = new Buffer(trs.secondSignature, 'hex');
+		var signSignatureBuffer = Buffer.from(trs.secondSignature, 'hex');
 		for (var i = 0; i < signSignatureBuffer.length; i++) {
 			bb.writeByte(signSignatureBuffer[i]);
 		}
@@ -185,19 +185,19 @@ function sign(transaction, keys) {
 	var hash = getHash(transaction, true, true);
 	var signature = nacl.sign.detached(hash, keys.keypair.secretKey);
 
-	return new Buffer(signature).toString("hex");
+	return Buffer.from(signature).toString("hex");
 }
 
 function secondSign(transaction, keys) {
 	var hash = getHash(transaction, true, true);
 	var signature = nacl.sign.detached(hash, keys.keypair.secretKey);
-	return new Buffer(signature).toString("hex")
+	return Buffer.from(signature).toString("hex")
 }
 
 function signBytes(bytes, keys) {
-	var hash = sha256Bytes(new Buffer(bytes, 'hex'))
+	var hash = sha256Bytes(Buffer.from(bytes, 'hex'))
 	var signature = nacl.sign.detached(hash, keys.keypair.secretKey);
-	return new Buffer(signature).toString("hex");
+	return Buffer.from(signature).toString("hex");
 }
 
 function verify(transaction) {
@@ -208,7 +208,7 @@ function verify(transaction) {
 	}
 
 	var bytes = getBytes(transaction);
-	var data2 = new Buffer(bytes.length - remove);
+	var data2 = Buffer.alloc(bytes.length - remove, 0);
 
 	for (var i = 0; i < data2.length; i++) {
 		data2[i] = bytes[i];
@@ -216,8 +216,8 @@ function verify(transaction) {
 
 	var hash = sha256Bytes(data2)
 
-	var signatureBuffer = new Buffer(transaction.signatures[0], "hex");
-	var senderPublicKeyBuffer = new Buffer(transaction.senderPublicKey, "hex");
+	var signatureBuffer = Buffer.from(transaction.signatures[0], "hex");
+	var senderPublicKeyBuffer = Buffer.from(transaction.senderPublicKey, "hex");
 	var res = nacl.sign.detached.verify(hash, signatureBuffer, senderPublicKeyBuffer);
 
 	return res;
@@ -225,7 +225,7 @@ function verify(transaction) {
 
 function verifySecondSignature(transaction, publicKey) {
 	var bytes = getBytes(transaction, true, true);
-	var data2 = new Buffer(bytes.length);
+	var data2 = Buffer.alloc(bytes.length, 0);
 
 	for (var i = 0; i < data2.length; i++) {
 		data2[i] = bytes[i];
@@ -233,29 +233,29 @@ function verifySecondSignature(transaction, publicKey) {
 
 	var hash = sha256Bytes(data2)
 
-	var signSignatureBuffer = new Buffer(transaction.secondSignature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
+	var signSignatureBuffer = Buffer.from(transaction.secondSignature, "hex");
+	var publicKeyBuffer = Buffer.from(publicKey, "hex");
 	var res = nacl.sign.detached.verify(hash, signSignatureBuffer, publicKeyBuffer);
 
 	return res;
 }
 
 function verifyBytes(bytes, signature, publicKey) {
-	var hash = sha256Bytes(new Buffer(bytes, 'hex'))
-	var signatureBuffer = new Buffer(signature, "hex");
-	var publicKeyBuffer = new Buffer(publicKey, "hex");
+	var hash = sha256Bytes(Buffer.from(bytes, 'hex'))
+	var signatureBuffer = Buffer.from(signature, "hex");
+	var publicKeyBuffer = Buffer.from(publicKey, "hex");
 	var res = nacl.sign.detached.verify(hash, signatureBuffer, publicKeyBuffer);
 	return res
 }
 
 function getKeys(secret) {
-	var hash = sha256Bytes(new Buffer(secret))
+	var hash = sha256Bytes(Buffer.from(secret))
 	var keypair = nacl.sign.keyPair.fromSeed(hash);
 
 	return {
 		keypair,
-		publicKey: new Buffer(keypair.publicKey).toString("hex"),
-		privateKey: new Buffer(keypair.secretKey).toString("hex")
+		publicKey: Buffer.from(keypair.publicKey).toString("hex"),
+		privateKey: Buffer.from(keypair.secretKey).toString("hex")
 	}
 }
 

--- a/lib/transactions/dapp.js
+++ b/lib/transactions/dapp.js
@@ -28,7 +28,7 @@ function getDAppTransactionBytes(trs, skipSignature) {
 	bb.writeInt(trs.timestamp);
 	bb.writeString(trs.fee)
 
-	var senderPublicKeyBuffer = new Buffer(trs.senderPublicKey, 'hex');
+	var senderPublicKeyBuffer = Buffer.from(trs.senderPublicKey, 'hex');
 	for (var i = 0; i < senderPublicKeyBuffer.length; i++) {
 		bb.writeByte(senderPublicKeyBuffer[i]);
 	}
@@ -39,7 +39,7 @@ function getDAppTransactionBytes(trs, skipSignature) {
 	bb.writeString(JSON.stringify(trs.args))
 
 	if (!skipSignature && trs.signature) {
-		var signatureBuffer = new Buffer(trs.signature, 'hex');
+		var signatureBuffer = Buffer.from(trs.signature, 'hex');
 		for (var i = 0; i < signatureBuffer.length; i++) {
 			bb.writeByte(signatureBuffer[i]);
 		}


### PR DESCRIPTION
Dear @sqfasd , dear @liangpeili 

this pull request closes the security issue https://github.com/AschPlatform/asch-js/issues/22

### What I did
- Replaced calls to `new Buffer("string", "encoding")` -> `Buffer.from("string", "encoding")`
- Replaced calls to `new Buffer([])` -> `Buffer.from([])`
- Replaced calls to `new Buffer(integer)` -> `Buffer.alloc(interger, 0)` (Buffer will be initialized with ZEROs)
- Replaced calls to `new Buffer(ArrayBuffer)` -> `Buffer.from(ArrayBuffer)`

Thanks for the review!
All the best!
a1300