### PR TITLE
chore(2ndSignature): add deprecated func signature.createSignature() for backwards compatibilty

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
 	dapp: require("./lib/transactions/dapp.js"),
 	transfer: require("./lib/transactions/transfer.js"),
 	delegate : require("./lib/transactions/delegate.js"),
+	signature: require('./lib/transactions/signature.js'),
 	transaction : require("./lib/transactions/transaction.js"),
 	vote : require("./lib/transactions/vote.js"),
 	uia: require("./lib/transactions/uia.js"),

--- a/lib/transactions/signature.js
+++ b/lib/transactions/signature.js
@@ -1,0 +1,12 @@
+var basic = require('./basic.js')
+
+/**
+	* @deprecated use instead basic.setSecondSecret(secret, secondSecret)
+	*/
+function createSignature (secret, secondSecret) {
+	return basic.setSecondSecret(secret, secondSecret)
+}
+
+module.exports = {
+	createSignature: createSignature
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,6 +109,16 @@ interface Delegate {
 }
 
 /*
+  signature.js
+*/
+interface Signature {
+  /**
+   * @deprecated Use instead basic.setSecondSecret(secret, secondSecret)
+   */
+  createSignature: (secret: string, secondSecret: string) => MainchainTransaction;
+}
+
+/*
   vote.js
 */
 interface Vote {
@@ -256,6 +266,7 @@ declare const asch_js: {
   dapp: Dapp,
   transfer: Transfer,
   delegate: Delegate,
+  signature: Signature,
   transaction: Transaction,
   vote: Vote,
   uia: Uia,


### PR DESCRIPTION
Dear @sqfasd, dear @liangpeili,

this commit (867d3410ab67166a25ee9a7c8d4a3b5a65fcea86) brings the public asch-js API to its previous state. I did this to prevent a major version bump (which would be necessary according to [Semantic Versioning](https://semver.org/).

In pull request #18 the API changed from `aschJS.signature.secondSecret()` to `aschJS.basic.setSecondSecret()`. Now I restored the removed function `aschJS.signature.secondSecret()` and added a `@deprecated` tag to it.

In the next major asch-js version the `aschJS.signature.secondSecret()` API can be removed.

Thanks for the review!
All the best!
a1300