### PR TITLE
fix(halting): remove signatures[] from chain.createInnerTransaction

### DIFF
--- a/lib/transactions/chain.js
+++ b/lib/transactions/chain.js
@@ -57,8 +57,7 @@ function createInnerTransaction(options, secret) {
 		timestamp: slots.getTime() - globalOptions.get('clientDriftSeconds'),
 		senderPublicKey: keys.publicKey,
 		type: options.type,
-		args: args,
-		signatures: []
+		args: args
 	}
 	trs.signature = crypto.signBytes(getChainTransactionBytes(trs), keys)
 	return trs


### PR DESCRIPTION
Dear @liangpeili 

this commit fixes the sandbox halting problem.

All the best!
a1300